### PR TITLE
Add bibtex and biber

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,7 @@ RUN apt-get update -q -y && apt-get install -q -y --no-install-recommends \
         texlive-latex-extra \
         texlive-fonts-extra \
         texlive-science \
+        texlive-bibtex-extra \
+        biber
         && rm -rf /var/lib/apt/lists/*
 COPY bin/* /usr/local/bin/


### PR DESCRIPTION
I currently have to install biber in my CI pipeline manually via `apt-get update -qq && apt-get install -qq texlive-bibtex-extra biber`. I think it would be useful to directly provide it through this docker container. But I can, of course, also create my own container on top of this one.